### PR TITLE
Add joliet extensions to CD image explicitly on macOS

### DIFF
--- a/anita.py
+++ b/anita.py
@@ -770,7 +770,7 @@ class Version(object):
             elif os.uname()[0] == 'FreeBSD':
                 makefs = mkisofs
             elif os.uname()[0] == 'Darwin':
-                makefs = ["hdiutil", "makehybrid", "-iso", "-o"]
+                makefs = ["hdiutil", "makehybrid", "-iso", "-joliet", "-o"]
             else:
                 # Linux distributions differ.  Ubuntu has genisoimage
                 # and mkisofs (as an alias of genisoimage); CentOS has


### PR DESCRIPTION
On macOS, anita creates a CD image with `hdiutil makehybrid -iso`. In macOS Sonoma, from what I can see, this results in an image that's pure ISO9660, without Joliet or Rockridge extensions. This could be an OS bug, as the documentation states that RockRidge is always enabled.

Explicitly add the `-joliet` flag to the invocation so that the required "long" file names for an amd64 installation are present.

Fixes #14 